### PR TITLE
Update baseimage to 4.3.x

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,7 +23,7 @@
       "matchDatasources": ["docker"],
       "matchPackageNames": ["netboxcommunity/netbox"],
       "versioning": "semver",
-      "allowedVersions": "<4.3.0"
+      "allowedVersions": "<4.4.0"
     }
   ]
 }

--- a/.github/workflows/check-netbox-versions.yml
+++ b/.github/workflows/check-netbox-versions.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const MIN_BLOCKED_VERSION = "4.3.0";
+            const MIN_BLOCKED_VERSION = "4.4.0";
             const REPO = "netboxcommunity/netbox";
             const issueLabel = "netbox-version-blocked";
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # checkov:skip=CKV_DOCKER_3: we don't want to drift away from upstream. so we keep it as it is
 # checkov:skip=CKV_DOCKER_7: yes, latest is okay here
 # hadolint ignore=DL3007
-FROM netboxcommunity/netbox:v4.2.9@sha256:7bf0eb72ba8079ebbc053f0d324654b3482bafde2f34ff07fa6777533171c337
+FROM netboxcommunity/netbox:v4.3.1@sha256:06efb429e1c5d12a557b0146175e2c7dc90c24ccc56095fba19704542e3e4e55
 
 COPY ./plugin_requirements.txt /opt/netbox/
 


### PR DESCRIPTION
Looks like the [breaking changes of 4.3](https://netboxlabs.com/docs/netbox/release-notes/version-4.3#breaking-changes) takes a lot of work on plugins developers, especially the  graphql changes. 