### PR TITLE
Revert "Use tag 4.0.2, which is the latest version compatible below 5.0"

### DIFF
--- a/.github/workflows/docker.image.yml
+++ b/.github/workflows/docker.image.yml
@@ -147,8 +147,7 @@ jobs:
       # See https://github.com/netbox-community/netbox-docker/blob/0c99ff8b5663db3e0db5a45660cebda9f917508b/.github/workflows/release.yml#L47
       - name: Download netbox-docker test scripts
         run: |
-          # newest script is only compatible with netxbox => 5.0.0
-          git clone --branch 4.0.2 --depth 1 https://github.com/netbox-community/netbox-docker.git /tmp/netbox-docker
+          git clone https://github.com/netbox-community/netbox-docker.git /tmp/netbox-docker
       - name: Test the Docker image for static files
         run: |
           CONTAINER_OUTPUT="$(docker run --rm -t localhost:5000/foobar/${{ env.IMAGE_NAME }} ls -1 /opt/netbox/netbox/static/netbox_floorplan/ | wc -l)"


### PR DESCRIPTION
This reverts commit 15b848f13dafa5268612e89caa96f931744d279d.